### PR TITLE
Added missing suggest and bin sections into composer Package struct

### DIFF
--- a/mirror/composer/composer_structs.go
+++ b/mirror/composer/composer_structs.go
@@ -40,6 +40,7 @@ type Package struct {
 	Version           string   `json:"version"`
 	VersionNormalized string   `json:"version_normalized"`
 	License           []string `json:"license"`
+	Bin               []string `json:"bin"`
 	Authors           []struct {
 		Name  string `json:"name"`
 		Email string `json:"email"`
@@ -60,6 +61,7 @@ type Package struct {
 	Autoload      *json.RawMessage  `json:"autoload"`
 	Require       map[string]string `json:"require"`
 	RequireDevmap map[string]string `json:"require-dev"`
+	Suggest       map[string]string `json:"suggest"`
 	UID           int               `json:"uid"`
 }
 


### PR DESCRIPTION
I currently have an issue because composer does not create the `vendor/bin/phpunit` directory when I run composer install with `phpunit/phpunit` as a dependency.

It looks that it's because the `bin` section are missing from the struct. I've also added the `suggest` one which is missing too.